### PR TITLE
making compatibile with latest version of serverless-haskell

### DIFF
--- a/src/AWSLambda/Events/APIGateway/Wai/Internal.hs
+++ b/src/AWSLambda/Events/APIGateway/Wai/Internal.hs
@@ -12,7 +12,8 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Lazy as Lazy
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
-import Data.Maybe (fromMaybe)
+import Data.IP (toHostAddress)
+import Data.Maybe (fromJust, fromMaybe)
 import Data.Semigroup ((<>))
 import Data.Text (splitOn)
 import Data.Text.Encoding (decodeUtf8)
@@ -50,8 +51,8 @@ toWaiRequest f first req = Wai.Request {..}
     remoteHost =
       Net.SockAddrInet
         443
-        (req ^. agprqRequestContext . prcIdentity . riSourceIp .
-         to Net.tupleToHostAddress)
+        (toHostAddress $ read . show $
+         fromJust $ req ^. agprqRequestContext . prcIdentity . riSourceIp)
     pathInfo = req ^. agprqPath . to (tail . splitOn "/" . decodeUtf8)
     queryString = req ^. agprqQueryStringParameters
     requestBody' = req ^? AWS.requestBody . _Just . to f

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
 resolver: lts-11.9
 packages:
 - .
-- ../serverless-haskell
 extra-deps:
-  - amazonka-core-1.6.0
-  - amazonka-kinesis-1.6.0
-  - amazonka-s3-1.6.0
+- serverless-haskell-0.6.1
+- amazonka-core-1.6.0
+- amazonka-kinesis-1.6.0
+- amazonka-s3-1.6.0
 nix:
   packages:
     - zlib.dev

--- a/wai-gateway.cabal
+++ b/wai-gateway.cabal
@@ -30,6 +30,7 @@ library
       base >=4.7 && <5
     , bytestring
     , http-types
+    , iproute
     , lens
     , network
     , serverless-haskell


### PR DESCRIPTION
Updating to handle `serverless-haskell`'s usage of the IP type from `iproute` for the request's source IP. The package doesn't build with the latest version of `serverless-haskell` without this change.

See: https://github.com/colehaus/serverless-haskell/commit/bf51b33a01e37fe1bdbf3997296e8d7a7b46c4f9